### PR TITLE
Config option to disable weapon wheel

### DIFF
--- a/client/weaponwheel.lua
+++ b/client/weaponwheel.lua
@@ -1,0 +1,11 @@
+-- Disable Controls 
+if Config.DisableWeaponWheel then
+CreateThread(function()
+    while true do
+        Wait(3)
+        -- Weapons | since you have a inventory
+        DisableControlAction(0, 0xAC4BD4F1, true) -- Disable weapon wheel | TAB (while holding)
+        -- LEFT ALT HUD
+        DisableControlAction(0, 0xCF8A4ECA, true) -- disable left alt hud | LEFT ALT (fast tapping)
+    end
+end)

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,8 @@ Config = {}
 Config.EnableProne = true
 Config.JointEffectTime = 60
 
+Config.DisableWeaponWheel = true
+
 ConsumeablesEat = {
 	["sandwich"] = math.random(35, 54),
     ["apple"] = math.random(10, 25),


### PR DESCRIPTION
Config option to disable weapon wheel due to being able to use hot keys to use items/weapons